### PR TITLE
Expand vite version range: allow v4

### DIFF
--- a/.changeset/chatty-houses-peel.md
+++ b/.changeset/chatty-houses-peel.md
@@ -1,0 +1,5 @@
+---
+"@joshwooding/vite-plugin-react-docgen-typescript": patch
+---
+
+Expand vite version range: allow v4

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "typescript": ">= 4.3.x",
-    "vite": "^3.0.0"
+    "vite": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,7 +684,10 @@ __metadata:
     vitest: ^0.25.8
   peerDependencies:
     typescript: ">= 4.3.x"
-    vite: ^3.0.0
+    vite: ^3.0.0 || ^4.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Applying the change as discussed here:
https://github.com/joshwooding/vite-plugin-react-docgen-typescript/pull/8#discussion_r1049044317

Includes changes from: https://github.com/joshwooding/vite-plugin-react-docgen-typescript/pull/8
Please merge that first?