### PR TITLE
fix: Changes on source files were not considered after init

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "glob": "^7.2.0",
-    "glob-promise": "^4.2.0",
     "magic-string": "^0.27.0",
     "react-docgen-typescript": "^2.2.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,85 +1,82 @@
 import { type Plugin, createFilter } from "vite";
-import * as path from "path";
-import glob from "glob-promise";
 import type { Options } from "./utils/options";
+import type { CompilerOptions } from "typescript";
+
+const getProgram = async (
+  sourcePath: string,
+  compilerOptions: CompilerOptions
+) => {
+  const { default: ts } = await import("typescript");
+
+  return ts.createProgram([sourcePath], compilerOptions);
+};
 
 const getUtils = async (config: Options) => {
-	const docGen = await import("react-docgen-typescript");
-	const { default: ts } = await import("typescript");
-	const { generateDocgenCodeBlock } = await import("./utils/generate");
-	const { getOptions } = await import("./utils/options");
+  const docGen = await import("react-docgen-typescript");
+  const { generateDocgenCodeBlock } = await import("./utils/generate");
+  const { getOptions } = await import("./utils/options");
 
-	const { docgenOptions, compilerOptions, generateOptions } =
-		getOptions(config);
+  const { docgenOptions, compilerOptions, generateOptions } =
+    getOptions(config);
 
-	const docGenParser = docGen.withCompilerOptions(
-		compilerOptions,
-		docgenOptions,
-	);
-	const { exclude = ["**/**.stories.tsx"], include = ["**/**.tsx"] } =
-		docgenOptions;
-	const filter = createFilter(include, exclude);
+  const docGenParser = docGen.withCompilerOptions(
+    compilerOptions,
+    docgenOptions
+  );
+  const { exclude = ["**/**.stories.tsx"], include = ["**/**.tsx"] } =
+    docgenOptions;
+  const filter = createFilter(include, exclude);
 
-	const files = include
-		.map((filePath) =>
-			glob.sync(
-				path.isAbsolute(filePath)
-					? filePath
-					: path.join(process.cwd(), filePath),
-			),
-		)
-		.reduce((carry, files) => carry.concat(files), []);
+  const result = {
+    docGenParser,
+    filter,
+    generateOptions,
+    compilerOptions,
+    generateDocgenCodeBlock,
+  };
 
-	const tsProgram = ts.createProgram(files, compilerOptions);
-
-	const result = {
-		docGenParser,
-		filter,
-		generateOptions,
-		generateDocgenCodeBlock,
-		tsProgram,
-	};
-
-	return result;
+  return result;
 };
 
 export default function reactDocgenTypescript(config: Options = {}): Plugin {
-	const utilsPromise = getUtils(config);
+  const utilsPromise = getUtils(config);
 
-	return {
-		name: "vite:react-docgen-typescript",
-		async transform(src, id) {
-			try {
-				const {
-					filter,
-					docGenParser,
-					generateOptions,
-					generateDocgenCodeBlock,
-					tsProgram,
-				} = await utilsPromise;
+  return {
+    name: "vite:react-docgen-typescript",
+    async transform(src, id) {
+      try {
+        const {
+          filter,
+          docGenParser,
+          generateOptions,
+          compilerOptions,
+          generateDocgenCodeBlock,
+        } = await utilsPromise;
 
-				if (!filter(id)) {
-					return;
-				}
+        const tsProgram = await getProgram(id, compilerOptions);
 
-				const componentDocs = docGenParser.parseWithProgramProvider(
-					id,
-					() => tsProgram,
-				);
+        if (!filter(id)) {
+          return;
+        }
 
-				if (!componentDocs.length) {
-					return null;
-				}
+        const componentDocs = docGenParser.parseWithProgramProvider(
+          id,
+          () => tsProgram
+        );
 
-				return generateDocgenCodeBlock({
-					filename: id,
-					source: src,
-					componentDocs,
-					...generateOptions,
-				});
-			} catch (e) {
-				return src;
-			}
-		},
-	};
+        if (!componentDocs.length) {
+          return null;
+        }
+
+        return generateDocgenCodeBlock({
+          filename: id,
+          source: src,
+          componentDocs,
+          ...generateOptions,
+        });
+      } catch (e) {
+        return src;
+      }
+    },
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,80 +3,80 @@ import type { Options } from "./utils/options";
 import type { CompilerOptions } from "typescript";
 
 const getProgram = async (
-  sourcePath: string,
-  compilerOptions: CompilerOptions
+	sourcePath: string,
+	compilerOptions: CompilerOptions,
 ) => {
-  const { default: ts } = await import("typescript");
+	const { default: ts } = await import("typescript");
 
-  return ts.createProgram([sourcePath], compilerOptions);
+	return ts.createProgram([sourcePath], compilerOptions);
 };
 
 const getUtils = async (config: Options) => {
-  const docGen = await import("react-docgen-typescript");
-  const { generateDocgenCodeBlock } = await import("./utils/generate");
-  const { getOptions } = await import("./utils/options");
+	const docGen = await import("react-docgen-typescript");
+	const { generateDocgenCodeBlock } = await import("./utils/generate");
+	const { getOptions } = await import("./utils/options");
 
-  const { docgenOptions, compilerOptions, generateOptions } =
-    getOptions(config);
+	const { docgenOptions, compilerOptions, generateOptions } =
+		getOptions(config);
 
-  const docGenParser = docGen.withCompilerOptions(
-    compilerOptions,
-    docgenOptions
-  );
-  const { exclude = ["**/**.stories.tsx"], include = ["**/**.tsx"] } =
-    docgenOptions;
-  const filter = createFilter(include, exclude);
+	const docGenParser = docGen.withCompilerOptions(
+		compilerOptions,
+		docgenOptions,
+	);
+	const { exclude = ["**/**.stories.tsx"], include = ["**/**.tsx"] } =
+		docgenOptions;
+	const filter = createFilter(include, exclude);
 
-  const result = {
-    docGenParser,
-    filter,
-    generateOptions,
-    compilerOptions,
-    generateDocgenCodeBlock,
-  };
+	const result = {
+		docGenParser,
+		filter,
+		generateOptions,
+		compilerOptions,
+		generateDocgenCodeBlock,
+	};
 
-  return result;
+	return result;
 };
 
 export default function reactDocgenTypescript(config: Options = {}): Plugin {
-  const utilsPromise = getUtils(config);
+	const utilsPromise = getUtils(config);
 
-  return {
-    name: "vite:react-docgen-typescript",
-    async transform(src, id) {
-      try {
-        const {
-          filter,
-          docGenParser,
-          generateOptions,
-          compilerOptions,
-          generateDocgenCodeBlock,
-        } = await utilsPromise;
+	return {
+		name: "vite:react-docgen-typescript",
+		async transform(src, id) {
+			try {
+				const {
+					filter,
+					docGenParser,
+					generateOptions,
+					compilerOptions,
+					generateDocgenCodeBlock,
+				} = await utilsPromise;
 
-        const tsProgram = await getProgram(id, compilerOptions);
+				const tsProgram = await getProgram(id, compilerOptions);
 
-        if (!filter(id)) {
-          return;
-        }
+				if (!filter(id)) {
+					return;
+				}
 
-        const componentDocs = docGenParser.parseWithProgramProvider(
-          id,
-          () => tsProgram
-        );
+				const componentDocs = docGenParser.parseWithProgramProvider(
+					id,
+					() => tsProgram,
+				);
 
-        if (!componentDocs.length) {
-          return null;
-        }
+				if (!componentDocs.length) {
+					return null;
+				}
 
-        return generateDocgenCodeBlock({
-          filename: id,
-          source: src,
-          componentDocs,
-          ...generateOptions,
-        });
-      } catch (e) {
-        return src;
-      }
-    },
-  };
+				return generateDocgenCodeBlock({
+					filename: id,
+					source: src,
+					componentDocs,
+					...generateOptions,
+				});
+			} catch (e) {
+				return src;
+			}
+		},
+	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,8 +672,6 @@ __metadata:
   dependencies:
     "@changesets/cli": ^2.25.2
     "@types/react": ^17.0.38
-    glob: ^7.2.0
-    glob-promise: ^4.2.0
     magic-string: ^0.27.0
     react: ^17.0.2
     react-docgen-typescript: ^2.2.2
@@ -985,29 +983,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.3":
-  version: 7.2.0
-  resolution: "@types/glob@npm:7.2.0"
-  dependencies:
-    "@types/minimatch": "*"
-    "@types/node": "*"
-  checksum: 6ae717fedfdfdad25f3d5a568323926c64f52ef35897bcac8aca8e19bc50c0bd84630bbd063e5d52078b2137d8e7d3c26eabebd1a2f03ff350fff8a91e79fc19
-  languageName: node
-  linkType: hard
-
 "@types/is-ci@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/is-ci@npm:3.0.0"
   dependencies:
     ci-info: ^3.1.0
   checksum: 7c1f1f16c1fa2134de7400d82766c83fa76057261ba890628af77a09382ebb92d945bb077b98cfcf3d40ab1469c9ffbd2278112867edbe57aa655f53547eb139
-  languageName: node
-  linkType: hard
-
-"@types/minimatch@npm:*":
-  version: 3.0.5
-  resolution: "@types/minimatch@npm:3.0.5"
-  checksum: c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
   languageName: node
   linkType: hard
 
@@ -2368,18 +2349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-promise@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "glob-promise@npm:4.2.2"
-  dependencies:
-    "@types/glob": ^7.1.3
-  peerDependencies:
-    glob: ^7.1.6
-  checksum: c1a3d95f7c8393e4151d4899ec4e42bb2e8237160f840ad1eccbe9247407da8b6c13e28f463022e011708bc40862db87b9b77236d35afa3feb8aa86d518f2dfe
-  languageName: node
-  linkType: hard
-
-"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.2.0":
+"glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:


### PR DESCRIPTION
After the plugin was initialized, changes on the source files were not considered anymore.

I have changed the logic, where a new ts program is created for every file change. The program also only considers the actual file and not a glob of all possible files.