### PR TITLE
Improve performance

### DIFF
--- a/.changeset/witty-cats-smash.md
+++ b/.changeset/witty-cats-smash.md
@@ -1,0 +1,5 @@
+---
+"@joshwooding/vite-plugin-react-docgen-typescript": patch
+---
+
+Improved performance

--- a/packages/vite-plugin-react-docgen-typescript/package.json
+++ b/packages/vite-plugin-react-docgen-typescript/package.json
@@ -28,7 +28,6 @@
     "build": "unbuild"
   },
   "dependencies": {
-    "glob": "^10.0.0",
     "magic-string": "^0.27.0",
     "react-docgen-typescript": "^2.2.2"
   },

--- a/packages/vite-plugin-react-docgen-typescript/src/__tests__/index.test.ts
+++ b/packages/vite-plugin-react-docgen-typescript/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { describe, expect, it } from "vitest";
 import reactDocgenTypescript from "../index";
 
+const tsconfigPathForTest = path.resolve(__dirname, "tsconfig.test.json");
 const fixturesPath = path.resolve(__dirname, "__fixtures__");
 
 const fixtureTests = fs
@@ -20,7 +21,9 @@ const defaultPropValueFixture = fixtureTests.find(
 describe("component fixture", () => {
 	fixtureTests.forEach((fixture) => {
 		it(`${path.basename(fixture.id)} has code block generated`, async () => {
-			const plugin = reactDocgenTypescript();
+			const plugin = reactDocgenTypescript({
+				tsconfigPath: tsconfigPathForTest,
+			});
 			// @ts-ignore
 			await plugin.configResolved?.();
 			expect(
@@ -33,6 +36,7 @@ describe("component fixture", () => {
 
 it("generates value info for enums", async () => {
 	const plugin = reactDocgenTypescript({
+		tsconfigPath: tsconfigPathForTest,
 		shouldExtractLiteralValuesFromEnum: true,
 	});
 	// @ts-ignore

--- a/packages/vite-plugin-react-docgen-typescript/src/__tests__/tsconfig.test.json
+++ b/packages/vite-plugin-react-docgen-typescript/src/__tests__/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["./**/*"],
+	"exclude": []
+}

--- a/packages/vite-plugin-react-docgen-typescript/src/index.ts
+++ b/packages/vite-plugin-react-docgen-typescript/src/index.ts
@@ -1,6 +1,6 @@
 import { type FileParser } from "react-docgen-typescript";
 import type { CompilerOptions, Program } from "typescript";
-import { createFilter, type Plugin } from "vite";
+import { type Plugin } from "vite";
 import { defaultPropFilter } from "./utils/filter";
 import type { Options } from "./utils/options";
 
@@ -39,7 +39,7 @@ const startWatch = async (
 	const { default: ts } = await import("typescript");
 	const { getTSConfigFile } = await import("./utils/typescript");
 
-	let compilerOptions = {
+	let compilerOptions: CompilerOptions = {
 		jsx: ts.JsxEmit.React,
 		module: ts.ModuleKind.CommonJS,
 		target: ts.ScriptTarget.Latest,
@@ -78,11 +78,13 @@ const startWatch = async (
 };
 
 export default function reactDocgenTypescript(config: Options = {}): Plugin {
-	let tsProgram: any;
+	let tsProgram: Program;
 	let docGenParser: FileParser;
-	let generateDocgenCodeBlock: any;
-	let generateOptions: any;
-	let filter: any;
+	let generateDocgenCodeBlock: typeof import("./utils/generate")["generateDocgenCodeBlock"];
+	let generateOptions: ReturnType<
+		typeof import("./utils/options")["getGenerateOptions"]
+	>;
+	let filter: ReturnType<typeof import("vite")["createFilter"]>;
 	const moduleInvalidationQueue: Map<Filepath, InvalidateModule> = new Map();
 	let closeWatch: CloseWatch;
 

--- a/packages/vite-plugin-react-docgen-typescript/src/index.ts
+++ b/packages/vite-plugin-react-docgen-typescript/src/index.ts
@@ -1,9 +1,12 @@
-import * as path from "path";
-import { globSync } from "glob";
 import { type FileParser } from "react-docgen-typescript";
-import { type Plugin } from "vite";
+import type { CompilerOptions, Program } from "typescript";
+import { createFilter, type Plugin } from "vite";
 import { defaultPropFilter } from "./utils/filter";
 import type { Options } from "./utils/options";
+
+type Filepath = string;
+type InvalidateModule = () => void;
+type CloseWatch = () => void;
 
 const getDocgen = async (config: Options) => {
 	const docGen = await import("react-docgen-typescript");
@@ -29,7 +32,10 @@ const getDocgen = async (config: Options) => {
 	);
 };
 
-const getProgram = async (config: Options, oldProgram?: any) => {
+const startWatch = async (
+	config: Options,
+	onProgramCreatedOrUpdated: (program: Program) => void,
+) => {
 	const { default: ts } = await import("typescript");
 	const { getTSConfigFile } = await import("./utils/typescript");
 
@@ -39,28 +45,36 @@ const getProgram = async (config: Options, oldProgram?: any) => {
 		target: ts.ScriptTarget.Latest,
 	};
 
+	const tsconfigPath = config.tsconfigPath ?? "./tsconfig.json";
+
 	if (config.compilerOptions) {
 		compilerOptions = {
 			...compilerOptions,
 			...config.compilerOptions,
 		};
 	} else {
-		const tsconfigPath = config.tsconfigPath ?? "./tsconfig.json";
 		const { options: tsOptions } = getTSConfigFile(tsconfigPath);
 		compilerOptions = { ...compilerOptions, ...tsOptions };
 	}
 
-	const files = (config.include ?? ["**/**.tsx"])
-		.map((filePath) =>
-			globSync(
-				path.isAbsolute(filePath)
-					? filePath
-					: path.join(process.cwd(), filePath),
-			),
-		)
-		.reduce((carry, files) => carry.concat(files), []);
+	const host = ts.createWatchCompilerHost(
+		tsconfigPath,
+		compilerOptions,
+		ts.sys,
+		ts.createSemanticDiagnosticsBuilderProgram,
+		undefined,
+		() => {
+			/* suppress message */
+		},
+	);
+	host.afterProgramCreate = (program) => {
+		onProgramCreatedOrUpdated(program.getProgram());
+	};
 
-	return ts.createProgram(files, compilerOptions, undefined, oldProgram);
+	return new Promise<[Program, CloseWatch]>((resolve) => {
+		const watch = ts.createWatchProgram(host);
+		resolve([watch.getProgram().getProgram(), watch.close]);
+	});
 };
 
 export default function reactDocgenTypescript(config: Options = {}): Plugin {
@@ -69,6 +83,8 @@ export default function reactDocgenTypescript(config: Options = {}): Plugin {
 	let generateDocgenCodeBlock: any;
 	let generateOptions: any;
 	let filter: any;
+	const moduleInvalidationQueue: Map<Filepath, InvalidateModule> = new Map();
+	let closeWatch: CloseWatch;
 
 	return {
 		name: "vite:react-docgen-typescript",
@@ -80,7 +96,16 @@ export default function reactDocgenTypescript(config: Options = {}): Plugin {
 
 			docGenParser = await getDocgen(config);
 			generateOptions = getGenerateOptions(config);
-			tsProgram = await getProgram(config);
+			[tsProgram, closeWatch] = await startWatch(config, (program) => {
+				tsProgram = program;
+
+				Array.from(moduleInvalidationQueue.entries()).forEach(
+					([filepath, invalidateModule]) => {
+						invalidateModule();
+						moduleInvalidationQueue.delete(filepath);
+					},
+				);
+			});
 			filter = createFilter(
 				config.include ?? ["**/**.tsx"],
 				config.exclude ?? ["**/**.stories.tsx"],
@@ -111,8 +136,23 @@ export default function reactDocgenTypescript(config: Options = {}): Plugin {
 				return src;
 			}
 		},
-		async handleHotUpdate() {
-			tsProgram = await getProgram(config, tsProgram);
+		async handleHotUpdate({ file, server, modules }) {
+			if (!filter(file)) return;
+
+			const module = modules.find((mod) => mod.file === file);
+			if (!module) return;
+
+			moduleInvalidationQueue.set(file, () => {
+				server.moduleGraph.invalidateModule(
+					module,
+					undefined,
+					Date.now(),
+					true,
+				);
+			});
+		},
+		closeBundle() {
+			closeWatch();
 		},
 	};
 }

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": ["./stories/**/*"],
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["es2018"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "outDir": "dist",
+    "strict": true,
+    "sourceMap": true,
+    "target": "es2018",
+    "jsx": "react",
+    "strictNullChecks": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@joshwooding/vite-plugin-react-docgen-typescript@workspace:packages/vite-plugin-react-docgen-typescript"
   dependencies:
-    glob: ^10.0.0
     magic-string: ^0.27.0
     react-docgen-typescript: ^2.2.2
   peerDependencies:


### PR DESCRIPTION
I was facing the same issue #37 .

Upon investigation, we found that calling `createProgram` for each HMR was a bottleneck in a project with many module dependencies.
So I thought of replacing `createProgram` with `createWatchProgram` to speed up the re-creation of the compiler API on  HMR.

You can apply the following patch to reproduce the issue and test the effect of this fix.
(In version 0.3.1 and later, editing `playground/stories/MuiButton.tsx` causes lag in HMR.)

<details><summary>Patch for reproduction</summary>

```diff
diff --git a/playground/package.json b/playground/package.json
index 6ddfa94..2297a83 100644
--- a/playground/package.json
+++ b/playground/package.json
@@ -9,6 +9,9 @@
     "url": "https://github.com/joshwooding/vite-plugin-react-docgen-typescript.git"
   },
   "dependencies": {
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
+    "@mui/material": "^6.1.1",
     "@storybook/addon-essentials": "7.4.6",
     "@storybook/addon-interactions": "7.4.6",
     "@storybook/addon-links": "7.4.6",
diff --git a/playground/stories/MuiButton.stories.ts b/playground/stories/MuiButton.stories.ts
new file mode 100644
index 0000000..ae20bd1
--- /dev/null
+++ b/playground/stories/MuiButton.stories.ts
@@ -0,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { MuiButton } from "./MuiButton";
+
+const meta = {
+       title: "Example/MuiButton",
+       component: MuiButton,
+       parameters: {
+               layout: "centered",
+       },
+       tags: ["autodocs"],
+} satisfies Meta<typeof MuiButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+       args: {
+               color: "primary",
+       },
+};
diff --git a/playground/stories/MuiButton.tsx b/playground/stories/MuiButton.tsx
new file mode 100644
index 0000000..07ed1d9
--- /dev/null
+++ b/playground/stories/MuiButton.tsx
@@ -0,0 +1,9 @@
+import React from "react";
+import { Button, ButtonProps } from "@mui/material";
+import lodash from "lodash";
+
+export const MuiButton = (props: ButtonProps) => (
+       <Button {...lodash(props).omit("children").value()}>
+               {lodash(props).pick("children").value().children || "Text!-"}
+       </Button>
+);

```

</details>