### PR TITLE
Fix builds hanging if `EXPERIMENTAL_useWatchProgram` is enabled

### DIFF
--- a/.changeset/loud-months-jam.md
+++ b/.changeset/loud-months-jam.md
@@ -2,4 +2,4 @@
 "@joshwooding/vite-plugin-react-docgen-typescript": patch
 ---
 
-Add closeWatch call to buildEnd hook
+Fixed builds hanging if `EXPERIMENTAL_useWatchProgram` is enabled.

--- a/.changeset/loud-months-jam.md
+++ b/.changeset/loud-months-jam.md
@@ -1,0 +1,5 @@
+---
+"@joshwooding/vite-plugin-react-docgen-typescript": patch
+---
+
+Add closeWatch call to buildEnd hook

--- a/packages/vite-plugin-react-docgen-typescript/src/index.ts
+++ b/packages/vite-plugin-react-docgen-typescript/src/index.ts
@@ -203,5 +203,9 @@ export default function reactDocgenTypescript(config: Options = {}): Plugin {
       if (!config.EXPERIMENTAL_useWatchProgram) return;
       closeWatch();
     },
+    buildEnd() {
+      if (!config.EXPERIMENTAL_useWatchProgram) return;
+      closeWatch();
+    },
   };
 }


### PR DESCRIPTION
Adding the `buildEnd` rollup hook will actually call `closeWatch` when it's finished running as `closeBundle` never seems to be called in the storybook context.

Running `npx storybook@0.0.0-pr-30422-sha-3b8c2a95 upgrade` to get the latest storybook with this package 0.5.0 version applied.

Then in this [repo](https://github.com/LumaKernel/storybook-hang-issue) if you change the options to set `EXPERIMENTAL_useWatchProgram` to `true` it will still hang.

With this transient dependency applied as on override on my local dev using the `file:` protocol the storybook build will no longer hang and exit as expected.

Unsure how I would add tests for this?

Closes #53 